### PR TITLE
Fixed compilation for Gcc 4.8.3 (MingW).

### DIFF
--- a/lzsse2/lzsse2.cpp
+++ b/lzsse2/lzsse2.cpp
@@ -23,11 +23,11 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "lzsse2.h"
 #include <intrin.h>
 #include <memory.h>
 #include <stdint.h>
 #include <stdio.h>
+#include "lzsse2.h"
 
 #include <assert.h>
 
@@ -933,8 +933,10 @@ size_t LZSSE2_Decompress( const void* inputChar, size_t inputLength, void* outpu
     
     // Decoding loop with all buffer checks.
     {
-        const  uint8_t* inputEarlyEnd  = ( input + inputLength ) - END_PADDING_LITERALS;
-        uint8_t*        outputEarlyEnd = ( output + outputLength ) - END_PADDING_LITERALS;
+        const uint8_t* inputEarlyEnd;
+        uint8_t*        outputEarlyEnd;
+        inputEarlyEnd  = (( input + inputLength ) - END_PADDING_LITERALS);
+        outputEarlyEnd = ( output + outputLength ) - END_PADDING_LITERALS;
 
         while ( outputCursor < outputEarlyEnd && inputCursor < inputEarlyEnd )
         {

--- a/lzsse4/lzsse4.cpp
+++ b/lzsse4/lzsse4.cpp
@@ -23,11 +23,11 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "lzsse4.h"
 #include <intrin.h>
 #include <memory.h>
 #include <stdint.h>
 #include <stdio.h>
+#include "lzsse4.h"
 
 #pragma warning ( disable : 4127 )
 
@@ -818,8 +818,10 @@ size_t LZSSE4_Decompress( const void* inputChar, size_t inputLength, void* outpu
 
     // Decoding loop with all buffer checks.
     {
-        const  uint8_t* inputEarlyEnd  = ( input + inputLength ) - END_PADDING_LITERALS;
-        uint8_t*        outputEarlyEnd = ( output + outputLength ) - END_PADDING_LITERALS;
+        const  uint8_t* inputEarlyEnd;
+        uint8_t*        outputEarlyEnd;
+        inputEarlyEnd  = ( input + inputLength ) - END_PADDING_LITERALS;
+        outputEarlyEnd = ( output + outputLength ) - END_PADDING_LITERALS;
 
         while ( outputCursor < outputEarlyEnd && inputCursor < inputEarlyEnd )
         {

--- a/lzsse8/lzsse8.cpp
+++ b/lzsse8/lzsse8.cpp
@@ -23,11 +23,11 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "lzsse8.h"
 #include <intrin.h>
 #include <memory.h>
 #include <stdint.h>
 #include <stdio.h>
+#include "lzsse8.h"
 
 #pragma warning ( disable : 4127 )
 
@@ -862,8 +862,10 @@ size_t LZSSE8_Decompress( const void* inputChar, size_t inputLength, void* outpu
 
     // Decoding loop with all buffer checks.
     {
-        const  uint8_t* inputEarlyEnd  = ( input + inputLength ) - END_PADDING_LITERALS;
-        uint8_t*        outputEarlyEnd = ( output + outputLength ) - END_PADDING_LITERALS;
+        const  uint8_t* inputEarlyEnd;
+        uint8_t*        outputEarlyEnd;
+        inputEarlyEnd  = ( input + inputLength ) - END_PADDING_LITERALS;
+        outputEarlyEnd = ( output + outputLength ) - END_PADDING_LITERALS;
 
         while ( outputCursor < outputEarlyEnd && inputCursor < inputEarlyEnd )
         {


### PR DESCRIPTION
Include order changed so size_t is defined for headers.
Stopped pointer initialization on declaration - initialization was skipped by the goto, giving and error.