### PR TITLE
Make sure we don't overflow size_t when allocating the parser.

### DIFF
--- a/lzsse2/lzsse2.cpp
+++ b/lzsse2/lzsse2.cpp
@@ -96,6 +96,11 @@ struct LZSSE2_OptimalParseState
 
 LZSSE2_OptimalParseState* LZSSE2_MakeOptimalParseState( size_t bufferSize )
 {
+    if ( bufferSize && ( SIZE_MAX / sizeof( Arrival ) ) < bufferSize )
+    {
+        return nullptr;
+    }
+
     LZSSE2_OptimalParseState* result = reinterpret_cast< LZSSE2_OptimalParseState* >( ::malloc( sizeof( LZSSE2_OptimalParseState ) ) );
 
     result->bufferSize = bufferSize;

--- a/lzsse4/lzsse4.cpp
+++ b/lzsse4/lzsse4.cpp
@@ -471,6 +471,11 @@ struct LZSSE4_OptimalParseState
 
 LZSSE4_OptimalParseState* LZSSE4_MakeOptimalParseState( size_t bufferSize )
 {
+    if ( bufferSize && ( SIZE_MAX / sizeof( Arrival ) ) < bufferSize )
+    {
+        return nullptr;
+    }
+
     LZSSE4_OptimalParseState* result = reinterpret_cast< LZSSE4_OptimalParseState* >( ::malloc( sizeof( LZSSE4_OptimalParseState ) ) );
 
     result->bufferSize = bufferSize;

--- a/lzsse8/lzsse8.cpp
+++ b/lzsse8/lzsse8.cpp
@@ -129,6 +129,11 @@ struct LZSSE8_OptimalParseState
 
 LZSSE8_OptimalParseState* LZSSE8_MakeOptimalParseState( size_t bufferSize )
 {
+    if ( bufferSize && ( SIZE_MAX / sizeof( Arrival ) ) < bufferSize )
+    {
+        return nullptr;
+    }
+
     LZSSE8_OptimalParseState* result = reinterpret_cast< LZSSE8_OptimalParseState* >( ::malloc( sizeof( LZSSE8_OptimalParseState ) ) );
 
     result->bufferSize = bufferSize;


### PR DESCRIPTION
This is unlikely to occur (though technically possible) with 64-bit
pointers, but on platforms with a 32-bit pointers such as x32 it's
a very real possibility.  This would lead to silently allocating
less space than the code assumes, eventually leading to accessing
invalid memory.