### PR TITLE
Trivial fixes (prevent crash on low memory)

### DIFF
--- a/lzsse2/lzsse2.cpp
+++ b/lzsse2/lzsse2.cpp
@@ -103,10 +103,10 @@ LZSSE2_OptimalParseState* LZSSE2_MakeOptimalParseState( size_t bufferSize )
 
     LZSSE2_OptimalParseState* result = reinterpret_cast< LZSSE2_OptimalParseState* >( ::malloc( sizeof( LZSSE2_OptimalParseState ) ) );
 
-    result->bufferSize = bufferSize;
-
     if ( result != nullptr )
     {
+        result->bufferSize = bufferSize;
+
         result->arrivals = reinterpret_cast< Arrival* >( ::malloc( sizeof( Arrival ) * bufferSize ) );
 
         if ( result->arrivals == nullptr )

--- a/lzsse2/lzsse2.cpp
+++ b/lzsse2/lzsse2.cpp
@@ -27,6 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h>
 #include <stdint.h>
 #include <stddef.h>
+#include <algorithm>
 
 #include "lzsse2_platform.h"
 #include "lzsse2.h"
@@ -582,9 +583,11 @@ size_t LZSSE2_Decompress( const void* inputChar, size_t inputLength, void* outpu
     // Length it not work compressing, just copy initial values
     if ( outputLength == inputLength )
     {
-        memcpy( output, input, outputLength );
+        const size_t length{ std::min(inputLength, outputLength) };
+        
+        memcpy( output, input, length );
 
-        return inputLength;
+        return length;
     }
 
     const uint8_t* inputCursor  = input;

--- a/lzsse2/lzsse2.cpp
+++ b/lzsse2/lzsse2.cpp
@@ -101,13 +101,13 @@ LZSSE2_OptimalParseState* LZSSE2_MakeOptimalParseState( size_t bufferSize )
         return nullptr;
     }
 
-    LZSSE2_OptimalParseState* result = reinterpret_cast< LZSSE2_OptimalParseState* >( ::malloc( sizeof( LZSSE2_OptimalParseState ) ) );
+    LZSSE2_OptimalParseState* result = reinterpret_cast< LZSSE2_OptimalParseState* >( malloc( sizeof( LZSSE2_OptimalParseState ) ) );
 
     if ( result != nullptr )
     {
         result->bufferSize = bufferSize;
 
-        result->arrivals = reinterpret_cast< Arrival* >( ::malloc( sizeof( Arrival ) * bufferSize ) );
+        result->arrivals = reinterpret_cast< Arrival* >( malloc( sizeof( Arrival ) * bufferSize ) );
 
         if ( result->arrivals == nullptr )
         {
@@ -123,11 +123,11 @@ LZSSE2_OptimalParseState* LZSSE2_MakeOptimalParseState( size_t bufferSize )
 
 void LZSSE2_FreeOptimalParseState( LZSSE2_OptimalParseState* toFree )
 {
-    ::free( toFree->arrivals );
+    free( toFree->arrivals );
         
     toFree->arrivals = nullptr;
 
-    ::free( toFree );
+    free( toFree );
 }
 
 

--- a/lzsse2/lzsse2.cpp
+++ b/lzsse2/lzsse2.cpp
@@ -297,9 +297,11 @@ size_t LZSSE2_CompressOptimalParse( LZSSE2_OptimalParseState* state, const void*
         
     if ( inputLength < MIN_COMPRESSION_SIZE )
     {
-        memcpy( output, input, inputLength );
+        const size_t length{ std::min(inputLength, outputLength) };
+        
+        memcpy( output, input, length );
 
-        return inputLength;
+        return length;
     }
 
     const uint8_t* inputCursor      = input;

--- a/lzsse4/lzsse4.cpp
+++ b/lzsse4/lzsse4.cpp
@@ -478,10 +478,10 @@ LZSSE4_OptimalParseState* LZSSE4_MakeOptimalParseState( size_t bufferSize )
 
     LZSSE4_OptimalParseState* result = reinterpret_cast< LZSSE4_OptimalParseState* >( ::malloc( sizeof( LZSSE4_OptimalParseState ) ) );
 
-    result->bufferSize = bufferSize;
-
     if ( result != nullptr )
     {
+        result->bufferSize = bufferSize;
+    
         result->arrivals = reinterpret_cast< Arrival* >( ::malloc( sizeof( Arrival ) * bufferSize ) );
 
         if ( result->arrivals == nullptr )

--- a/lzsse4/lzsse4.cpp
+++ b/lzsse4/lzsse4.cpp
@@ -476,13 +476,13 @@ LZSSE4_OptimalParseState* LZSSE4_MakeOptimalParseState( size_t bufferSize )
         return nullptr;
     }
 
-    LZSSE4_OptimalParseState* result = reinterpret_cast< LZSSE4_OptimalParseState* >( ::malloc( sizeof( LZSSE4_OptimalParseState ) ) );
+    LZSSE4_OptimalParseState* result = reinterpret_cast< LZSSE4_OptimalParseState* >( malloc( sizeof( LZSSE4_OptimalParseState ) ) );
 
     if ( result != nullptr )
     {
         result->bufferSize = bufferSize;
     
-        result->arrivals = reinterpret_cast< Arrival* >( ::malloc( sizeof( Arrival ) * bufferSize ) );
+        result->arrivals = reinterpret_cast< Arrival* >( malloc( sizeof( Arrival ) * bufferSize ) );
 
         if ( result->arrivals == nullptr )
         {
@@ -498,11 +498,11 @@ LZSSE4_OptimalParseState* LZSSE4_MakeOptimalParseState( size_t bufferSize )
 
 void LZSSE4_FreeOptimalParseState( LZSSE4_OptimalParseState* toFree )
 {
-    ::free( toFree->arrivals );
+    free( toFree->arrivals );
 
     toFree->arrivals = nullptr;
 
-    ::free( toFree );
+    free( toFree );
 }
 
 

--- a/lzsse4/lzsse4.cpp
+++ b/lzsse4/lzsse4.cpp
@@ -115,9 +115,11 @@ size_t LZSSE4_CompressFast( LZSSE4_FastParseState* state, const void* inputChar,
 
     if ( inputLength < MIN_COMPRESSION_SIZE )
     {
-        memcpy( output, input, inputLength );
+        const size_t length{ std::min(inputLength, outputLength) };
+        
+        memcpy( output, input, length );
 
-        return inputLength;
+        return length;
     }
 
     const uint8_t* inputCursor    = input;

--- a/lzsse4/lzsse4.cpp
+++ b/lzsse4/lzsse4.cpp
@@ -27,6 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h>
 #include <stdint.h>
 #include <stddef.h>
+#include <algorithm>
 
 #include "lzsse4_platform.h"
 #include "lzsse4.h"
@@ -671,9 +672,11 @@ size_t LZSSE4_CompressOptimalParse( LZSSE4_OptimalParseState* state, const void*
 
     if ( inputLength < MIN_COMPRESSION_SIZE )
     {
-        memcpy( output, input, inputLength );
+        const size_t length{ std::min(inputLength, outputLength) };
+        
+        memcpy( output, input, length );
 
-        return inputLength;
+        return length;
     }
 
     const uint8_t* inputCursor      = input;

--- a/lzsse8/lzsse8.cpp
+++ b/lzsse8/lzsse8.cpp
@@ -136,10 +136,10 @@ LZSSE8_OptimalParseState* LZSSE8_MakeOptimalParseState( size_t bufferSize )
 
     LZSSE8_OptimalParseState* result = reinterpret_cast< LZSSE8_OptimalParseState* >( ::malloc( sizeof( LZSSE8_OptimalParseState ) ) );
 
-    result->bufferSize = bufferSize;
-
     if ( result != nullptr )
     {
+        result->bufferSize = bufferSize;
+    
         result->arrivals = reinterpret_cast< Arrival* >( ::malloc( sizeof( Arrival ) * bufferSize ) );
 
         if ( result->arrivals == nullptr )

--- a/lzsse8/lzsse8.cpp
+++ b/lzsse8/lzsse8.cpp
@@ -647,9 +647,11 @@ size_t LZSSE8_CompressFast( LZSSE8_FastParseState* state, const void* inputChar,
 
     if ( inputLength < MIN_COMPRESSION_SIZE )
     {
-        memcpy( output, input, inputLength );
+        const size_t length{ std::min(inputLength, outputLength) };
+        
+        memcpy( output, input, length );
 
-        return inputLength;
+        return length;
     }
 
     const uint8_t* inputCursor    = input;

--- a/lzsse8/lzsse8.cpp
+++ b/lzsse8/lzsse8.cpp
@@ -134,13 +134,13 @@ LZSSE8_OptimalParseState* LZSSE8_MakeOptimalParseState( size_t bufferSize )
         return nullptr;
     }
 
-    LZSSE8_OptimalParseState* result = reinterpret_cast< LZSSE8_OptimalParseState* >( ::malloc( sizeof( LZSSE8_OptimalParseState ) ) );
+    LZSSE8_OptimalParseState* result = reinterpret_cast< LZSSE8_OptimalParseState* >( malloc( sizeof( LZSSE8_OptimalParseState ) ) );
 
     if ( result != nullptr )
     {
         result->bufferSize = bufferSize;
     
-        result->arrivals = reinterpret_cast< Arrival* >( ::malloc( sizeof( Arrival ) * bufferSize ) );
+        result->arrivals = reinterpret_cast< Arrival* >( malloc( sizeof( Arrival ) * bufferSize ) );
 
         if ( result->arrivals == nullptr )
         {
@@ -156,11 +156,11 @@ LZSSE8_OptimalParseState* LZSSE8_MakeOptimalParseState( size_t bufferSize )
 
 void LZSSE8_FreeOptimalParseState( LZSSE8_OptimalParseState* toFree )
 {
-    ::free( toFree->arrivals );
+    free( toFree->arrivals );
 
     toFree->arrivals = nullptr;
 
-    ::free( toFree );
+    free( toFree );
 }
 
 

--- a/lzsse8/lzsse8.cpp
+++ b/lzsse8/lzsse8.cpp
@@ -27,6 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h>
 #include <stdint.h>
 #include <stddef.h>
+#include <algorithm>
 
 #include "lzsse8_platform.h"
 #include "lzsse8.h"
@@ -329,9 +330,11 @@ size_t LZSSE8_CompressOptimalParse( LZSSE8_OptimalParseState* state, const void*
 
     if ( inputLength < MIN_COMPRESSION_SIZE )
     {
-        memcpy( output, input, inputLength );
+        const size_t length{ std::min(inputLength, outputLength) };
+        
+        memcpy( output, input, length );
 
-        return inputLength;
+        return length;
     }
 
     const uint8_t* inputCursor      = input;


### PR DESCRIPTION
Test the result of malloc() before dereferencing the pointer.